### PR TITLE
Release version 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Release *v2.0.dev0* - ``2019-10-13``
-------------------------------------
+Release *v2* - ``2019-10-13``
+-----------------------------
 * Support for limpyd >= 2 only (redis-py >= 3, redis-server >= 3)
 
 Release *v1.1* - ``2019-10-12``

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = redis-limpyd-jobs
-version = 2.0.dev2
+version = 2
 author = Stephane "Twidi" Angel
 author_email = s.angel@twidi.com
 url = https://github.com/limpyd/redis-limpyd-jobs


### PR DESCRIPTION
v2: Support for limpyd >= 2 only (redis-py >= 3, redis-server >= 3)